### PR TITLE
Fix/update slack package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: read-resource post-resource
 
 read-resource:
-	docker build -t jakobleben/slack-read-resource -f read/Dockerfile .
+	docker build -t apptweak/slack-read-resource -f read/Dockerfile .
 
 post-resource:
-	docker build -t jakobleben/slack-post-resource -f post/Dockerfile .
+	docker build -t apptweak/slack-post-resource -f post/Dockerfile .

--- a/Readme.md
+++ b/Readme.md
@@ -19,8 +19,8 @@ with the following benefits:
 
 Docker Store:
 
-- [jakobleben/slack-read-resource](https://store.docker.com/community/images/jakobleben/slack-read-resource)
-- [jakobleben/slack-post-resource](https://store.docker.com/community/images/jakobleben/slack-post-resource)
+- [apptweak/slack-read-resource](https://store.docker.com/community/images/apptweak/slack-read-resource)
+- [apptweak/slack-post-resource](https://store.docker.com/community/images/apptweak/slack-post-resource)
 
 ## Version Format
 
@@ -38,7 +38,7 @@ Usage in a pipeline:
         - name: slack-read-resource
           type: docker-image
           source:
-            repository: jakobleben/slack-read-resource
+            repository: apptweak/slack-read-resource
 
     resources:
         - name: slack-in
@@ -122,7 +122,7 @@ Usage in a pipeline:
         - name: slack-post-resource
           type: docker-image
           source:
-            repository: jakobleben/slack-post-resource
+            repository: apptweak/slack-post-resource
 
     resources:
         - name: slack-out

--- a/post/Dockerfile
+++ b/post/Dockerfile
@@ -3,16 +3,16 @@ FROM golang:alpine as build-env
 RUN apk update
 RUN apk add git
 RUN go get github.com/nlopes/slack
-COPY ./utils /go/src/github.com/jleben/slack-chat-resource/utils
-RUN go build -o /assets/utils github.com/jleben/slack-chat-resource/utils
+COPY ./utils /go/src/github.com/apptweak/slack-chat-resource/utils
+RUN go build -o /assets/utils github.com/apptweak/slack-chat-resource/utils
 
 FROM build-env as build-post
-COPY ./post/check /go/src/github.com/jleben/slack-chat-resource/post/check/
-COPY ./post/in /go/src/github.com/jleben/slack-chat-resource/post/in/
-COPY ./post/out /go/src/github.com/jleben/slack-chat-resource/post/out/
-RUN go build -o /assets/check github.com/jleben/slack-chat-resource/post/check
-RUN go build -o /assets/in github.com/jleben/slack-chat-resource/post/in
-RUN go build -o /assets/out github.com/jleben/slack-chat-resource/post/out
+COPY ./post/check /go/src/github.com/apptweak/slack-chat-resource/post/check/
+COPY ./post/in /go/src/github.com/apptweak/slack-chat-resource/post/in/
+COPY ./post/out /go/src/github.com/apptweak/slack-chat-resource/post/out/
+RUN go build -o /assets/check github.com/apptweak/slack-chat-resource/post/check
+RUN go build -o /assets/in github.com/apptweak/slack-chat-resource/post/in
+RUN go build -o /assets/out github.com/apptweak/slack-chat-resource/post/out
 
 FROM alpine
 RUN apk update

--- a/post/Dockerfile
+++ b/post/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:alpine as build-env
 RUN apk update
 RUN apk add git
-RUN go get github.com/nlopes/slack
+RUN go get github.com/slack-go/slack
 COPY ./utils /go/src/github.com/apptweak/slack-chat-resource/utils
 RUN go build -o /assets/utils github.com/apptweak/slack-chat-resource/utils
 

--- a/post/out/main.go
+++ b/post/out/main.go
@@ -6,7 +6,7 @@ import (
     "os"
     "path/filepath"
     "fmt"
-    "github.com/jleben/slack-chat-resource/utils"
+    "github.com/apptweak/slack-chat-resource/utils"
     "github.com/nlopes/slack"
 )
 

--- a/post/out/main.go
+++ b/post/out/main.go
@@ -7,7 +7,7 @@ import (
     "path/filepath"
     "fmt"
     "github.com/apptweak/slack-chat-resource/utils"
-    "github.com/nlopes/slack"
+    "github.com/slack-go/slack"
 )
 
 func main() {

--- a/read/Dockerfile
+++ b/read/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:alpine as build-env
 RUN apk update
 RUN apk add git
-RUN go get github.com/nlopes/slack
+RUN go get github.com/slack-go/slack
 COPY ./utils /go/src/github.com/apptweak/slack-chat-resource/utils
 RUN go build -o /assets/utils github.com/apptweak/slack-chat-resource/utils
 

--- a/read/Dockerfile
+++ b/read/Dockerfile
@@ -3,16 +3,16 @@ FROM golang:alpine as build-env
 RUN apk update
 RUN apk add git
 RUN go get github.com/nlopes/slack
-COPY ./utils /go/src/github.com/jleben/slack-chat-resource/utils
-RUN go build -o /assets/utils github.com/jleben/slack-chat-resource/utils
+COPY ./utils /go/src/github.com/apptweak/slack-chat-resource/utils
+RUN go build -o /assets/utils github.com/apptweak/slack-chat-resource/utils
 
 FROM build-env as build-read
-COPY ./read/check /go/src/github.com/jleben/slack-chat-resource/read/check/
-COPY ./read/in /go/src/github.com/jleben/slack-chat-resource/read/in/
-COPY ./read/out /go/src/github.com/jleben/slack-chat-resource/read/out/
-RUN go build -o /assets/check github.com/jleben/slack-chat-resource/read/check
-RUN go build -o /assets/in github.com/jleben/slack-chat-resource/read/in
-RUN go build -o /assets/out github.com/jleben/slack-chat-resource/read/out
+COPY ./read/check /go/src/github.com/apptweak/slack-chat-resource/read/check/
+COPY ./read/in /go/src/github.com/apptweak/slack-chat-resource/read/in/
+COPY ./read/out /go/src/github.com/apptweak/slack-chat-resource/read/out/
+RUN go build -o /assets/check github.com/apptweak/slack-chat-resource/read/check
+RUN go build -o /assets/in github.com/apptweak/slack-chat-resource/read/in
+RUN go build -o /assets/out github.com/apptweak/slack-chat-resource/read/out
 
 FROM alpine
 RUN apk update

--- a/read/check/main.go
+++ b/read/check/main.go
@@ -10,7 +10,7 @@ import (
     //"strings"
     //"net/http"
     "github.com/apptweak/slack-chat-resource/utils"
-    "github.com/nlopes/slack"
+    "github.com/slack-go/slack"
 )
 
 func main() {

--- a/read/check/main.go
+++ b/read/check/main.go
@@ -9,7 +9,7 @@ import (
     "fmt"
     //"strings"
     //"net/http"
-    "github.com/jleben/slack-chat-resource/utils"
+    "github.com/apptweak/slack-chat-resource/utils"
     "github.com/nlopes/slack"
 )
 

--- a/read/check/main.go
+++ b/read/check/main.go
@@ -98,7 +98,7 @@ func get_messages(request *utils.CheckRequest, slack_client *slack.Client) *slac
     params.Count = 100
 
     var history *slack.History
-    history, err := slack_client.GetChannelHistory(request.Source.ChannelId, params)
+    history, err := GetConversationHistory(request.Source.ChannelId, params)
     if err != nil {
         fatal("getting messages.", err)
     }
@@ -163,7 +163,13 @@ func match_replies(message *slack.Message, request *utils.CheckRequest, slack_cl
         return false
     }
 
-    replies, err := slack_client.GetChannelReplies(request.Source.ChannelId, message.Msg.Timestamp)
+    conversation_replies = slack_client.GetConversationRepliesParameters{
+        ChannelID: request.Source.ChannelId,
+        Timestamp: message.Msg.Timestamp,
+    }
+
+    replies, _, _, err := slack_client.GetConversationReplies(conversation_replies)
+
     if err != nil {
         fatal("getting replies", err)
     }

--- a/read/check/main.go
+++ b/read/check/main.go
@@ -98,7 +98,7 @@ func get_messages(request *utils.CheckRequest, slack_client *slack.Client) *slac
     params.Count = 100
 
     var history *slack.History
-    history, err := GetConversationHistory(request.Source.ChannelId, params)
+    history, err := slack_client.GetConversationHistory(request.Source.ChannelId, params)
     if err != nil {
         fatal("getting messages.", err)
     }

--- a/read/in/main.go
+++ b/read/in/main.go
@@ -62,7 +62,7 @@ func get(request *utils.InRequest, destination string, slack_client *slack.Clien
     params.Inclusive = true
     params.Count = 1
 
-    history, history_err := slack_client.GetChannelHistory(request.Source.ChannelId, params)
+    history, history_err := GetConversationHistory(request.Source.ChannelId, params)
     if history_err != nil {
 		fatal("getting message", history_err)
 	}

--- a/read/in/main.go
+++ b/read/in/main.go
@@ -8,7 +8,7 @@ import (
     "fmt"
     //"strings"
     "github.com/apptweak/slack-chat-resource/utils"
-    "github.com/nlopes/slack"
+    "github.com/slack-go/slack"
 )
 
 

--- a/read/in/main.go
+++ b/read/in/main.go
@@ -62,7 +62,7 @@ func get(request *utils.InRequest, destination string, slack_client *slack.Clien
     params.Inclusive = true
     params.Count = 1
 
-    history, history_err := GetConversationHistory(request.Source.ChannelId, params)
+    history, history_err := slack_client.GetConversationHistory(request.Source.ChannelId, params)
     if history_err != nil {
 		fatal("getting message", history_err)
 	}

--- a/read/in/main.go
+++ b/read/in/main.go
@@ -7,7 +7,7 @@ import (
     "path/filepath"
     "fmt"
     //"strings"
-    "github.com/jleben/slack-chat-resource/utils"
+    "github.com/apptweak/slack-chat-resource/utils"
     "github.com/nlopes/slack"
 )
 

--- a/test/test-check.sh
+++ b/test/test-check.sh
@@ -7,4 +7,4 @@ if [[ -z $type || -z $request ]]; then
     exit 1
 fi
 
-cat "$request" | docker run --rm -i jakobleben/slack-$type-resource /opt/resource/check
+cat "$request" | docker run --rm -i apptweak/slack-$type-resource /opt/resource/check

--- a/test/test-in.sh
+++ b/test/test-in.sh
@@ -13,4 +13,4 @@ cat "$request" | docker run --rm -i \
 -e BUILD_PIPELINE_NAME=mypipe \
 -e BUILD_TEAM_NAME=myteam \
 -e ATC_EXTERNAL_URL="https://example.com" \
--v "$(pwd)/$type/in:/tmp/resource" jakobleben/slack-$type-resource /opt/resource/in /tmp/resource
+-v "$(pwd)/$type/in:/tmp/resource" apptweak/slack-$type-resource /opt/resource/in /tmp/resource

--- a/test/test-out.sh
+++ b/test/test-out.sh
@@ -13,4 +13,4 @@ cat "$request" | docker run --rm -i \
 -e BUILD_PIPELINE_NAME=mypipe \
 -e BUILD_TEAM_NAME=myteam \
 -e ATC_EXTERNAL_URL="https://example.com" \
--v "$(pwd)/$type/out:/tmp/resource" jakobleben/slack-$type-resource /opt/resource/out /tmp/resource
+-v "$(pwd)/$type/out:/tmp/resource" apptweak/slack-$type-resource /opt/resource/out /tmp/resource

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,7 +5,7 @@ import (
     "regexp"
     //"errors"
     "encoding/json"
-    "github.com/nlopes/slack"
+    "github.com/slack-go/slack"
 )
 
 type Regexp struct { regexp.Regexp }


### PR DESCRIPTION
## Description

Fixes jleben/slack-chat-resource#8

## Changes
- Update slack package from `github.com/nlopes/slack` to `github.com/slack-go/slack`
- Replace `slack_client.GetChannelHistory` by  `slack_client.GetConversationHistory` 